### PR TITLE
package: updated ibm_db to 2.x and node to ^4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "engines": {
-    "node": "0.10.33"
+    "node": "^4"
   },
   "name": "dashdbnodesample",
   "version": "0.0.1",
   "description": "A sample node app for connecting to dashDB service on Bluemix",
   "dependencies": {
-    "cf-deployment-tracker-client": "0.0.8",
-    "express": "3.5.x",
-    "ibm_db": "0.0.19",
-    "jade": "1.11.0"
+    "cf-deployment-tracker-client": "^0.0.8",
+    "express": "^3.5.3",
+    "ibm_db": "^2.0.0",
+    "jade": "^1.11.0"
   },
   "scripts": {
     "start": "node app.js"


### PR DESCRIPTION
update package engine field so it allows LTS node

update ibm_db to the latest, so it can install on LTS node

express should be updated to 4.x, cf-deployment-tracker should be at 1.x (0.x versions should not be published to npmjs.org), and jade should be replaced with pug, check the result of `npm outdated`