### PR TITLE
convert to Db2 on Cloud Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
-# Db2 Warehouse on Cloud -  Node.js Hello World Sample
+# Db2 on Cloud -  Node.js Hello World Sample
 
-The code in this repository provides a simple implementation of an app running on Node.js runtime demonstrating how to connect Node.js applications to the IBM Db2 Warehouse on Cloud service.
+The code in this repository provides a simple implementation of an app running on Node.js runtime demonstrating how to connect Node.js applications to the IBM Db2  on Cloud service.
 
-You can bind a IBM Db2 Warehouse on Cloud service instance to an app running on Node.js runtime in the IBM Cloud (Bluemix) and then work with the data in the Db2 database (relational SQL database). The Bluemix Node.js runtime will automatically lay down native driver dependencies when you have a Db2 Service instance bound to your app. The sample illustrated here uses express and jade node modules.
-
-For issues that you encounter with this service, go to [**Get help**](https://developer.ibm.com/bluemix/) in the Bluemix developer community.
-
-[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy)
-
-![Bluemix Deployments](https://deployment-tracker.mybluemix.net/stats/6dc62259729f4ccc57f616d7f1e7315b/badge.svg)
+You can bind a IBM Db2 on Cloud service instance to an app running on Node.js runtime in the IBM Cloud and then work with the data in the Db2 database (relational SQL database). The Node.js runtime will automatically lay down native driver dependencies when you have a Db2 Service instance bound to your app. The sample illustrated here uses express and jade node modules.
 
 ## Running the app on Bluemix
 
-1. If you do not already have a Bluemix account, [sign up here](https://console.ng.bluemix.net/registration/)
+1. If you do not already have a IBM Cloud account, [sign up here](https://cloud.ibm.com/registration)
 
-2. Download and install the [Cloud Foundry CLI](https://github.com/cloudfoundry/cli/releases) tool
+2. Download and install the [IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cli-install-ibmcloud-cli) tool
 
 3. Clone the app to your local environment from your terminal using the following command:
 
@@ -26,31 +20,33 @@ For issues that you encounter with this service, go to [**Get help**](https://de
 
 5. Open the `manifest.yml` file and change the `host` value to something unique.
 
-  The host you choose will determinate the subdomain of your application's URL:  `<host>.mybluemix.net`
+  The host you choose will determine the subdomain of your application's URL:  `<host>[.region].mybluemix.net`
 
-6. Connect to Bluemix in the command line tool and follow the prompts to log in.
-
-  ```
-  $ cf api https://api.ng.bluemix.net
-  $ cf login
-  ```
-
-7. Create a Db2 Warehouse on Cloud service instance in Bluemix.
+6. Connect to IBM Cloud in the command line tool and follow the prompts to log in.
+   You can find the most appropriate API endpoint for running your application at [Cloud Foundry](https://cloud.ibm.com/docs/cloud-foundry-public?topic=cloud-foundry-public-endpoints) - the following example assume a USA-based deployment.
 
   ```
-  $ cf create-service dashDB Entry dashDB-nodesample
+  $ ibmcloud cf api  https://api.us-south.cf.cloud.ibm.com  # USA
+  $ ibmcloud cf login
+  $ ibmcloud target --cf
   ```
 
-8. Push the app to Bluemix.
+7. Create a Db2 on Cloud service instance in IBM Cloud.
 
   ```
-  $ cf push
+  $ ibmcloud cf create-service "dashDB For Transactions" Lite dashDB-nodesample
+  ```
+
+8. Push the app to Cloud Foundry on IBM Cloud.
+
+  ```
+  $ ibmcloud cf push
   ```
 
 And voila! You now have your very own instance of an app running Node.js runtime and connecting and querying the dashDB service on Bluemix.
 
 ## Run the app locally
-1. If you do not already have a Bluemix account, [sign up here](https://console.ng.bluemix.net/registration/)
+1. If you do not already have an IBM Cloud account, [sign up here](https://cloud.ibm.com/registration)
 
 2. If you have not already, [download node.js](https://nodejs.org/en/download/) and install it on your local machine.
 
@@ -68,7 +64,7 @@ And voila! You now have your very own instance of an app running Node.js runtime
   npm install
   ```
 
-6. Create a dashDB service using your Bluemix account and replace the corresponding credentials in your app.js file
+6. Create a Db2 on Cloud service [Lite plan](https://cloud.ibm.com/catalog/services/db2) using your IBM Cloud account and replace the corresponding credentials in your app.js file
 
 ```
         db: "BLUDB",
@@ -87,7 +83,7 @@ And voila! You now have your very own instance of an app running Node.js runtime
 This command will start your application. When your app has started, your console will print that your `Express server listening on port 3000`.
 
 
-## Decomposition Instructions
+##Instructions
 
 The primary purpose of this demo is to provide a sample implementation of an app running on Node.js runtime demonstrating how to connect Node.js applications to Db2 Warehouse on Cloud service on Bluemix. The relevant code for this integration is located within the `app.js` file.
 
@@ -95,14 +91,14 @@ The following components are required to connect Db2 from a Node.js application.
 
 - package.json
 - Node.js program
-- A dashDB service instance
+- A Db2 on Cloud (dashDB for Transactions) Lite service instance
 
 #### package.json
 The package.json contains information about your app and its dependencies. It is used by npm tool to install, update, remove and manage the node modules you need. Add the ibm_db dependency to your package.json:
 ```
 {
   "engines": {
-    "node": "0.10.33"
+    "node": ">=0.10.0"
   },
   "name": "dashdbnodesample",
   "version": "0.0.1",
@@ -110,7 +106,7 @@ The package.json contains information about your app and its dependencies. It is
   "dependencies": {
     "cf-deployment-tracker-client": "0.0.8",
     "express": "3.5.x",
-    "ibm_db": "0.0.19",
+    "ibm_db": ">=2.0.0",
     "jade": "1.11.0"
   },
   "scripts": {
@@ -124,12 +120,11 @@ The package.json contains information about your app and its dependencies. It is
 
 ```
 
-
 ### Connecting to Db2 from Node.js code
 
 In your Node.js code, parse the VCAP_SERVICES environment variable to retrieve the database connection information and connect to the database as shown in the following example.
 
-For more information on the structure of the VCAP_SERVICES environment variable see [Getting Started with dashDB Service](http://www.ng.bluemix.net/docs/#services/dashDB/index.html#dashDB)
+For more information on the structure of the VCAP_SERVICES environment variable, see [Getting Started with Db2 Service](https://cloud.ibm.com/docs/Db2onCloud?topic=Db2onCloud-getting-started)
 
 ```
 var app = express();
@@ -157,16 +152,26 @@ exports.listSysTables = function(ibmdb,connString) {
 			 res.send("error occurred " + err.message);
 			}
 			else {
-				conn.query("SELECT FIRST_NAME, LAST_NAME, EMAIL, WORK_PHONE from GOSALESHR.employee FETCH FIRST 10 ROWS ONLY", function(err, tables, moreResultSets) {
-
-							
+				conn.query(
+				"SELECT 
+					schemaname as schema_name,
+    					owner as schema_owner,
+    					case ownertype 
+        					when 'S' then 'SYSTEM'
+        					when 'U' then 'USER' 
+    					end as schema_owner_type,
+    					definer as schema_definer,
+    					case definertype 
+        					when 'S' then 'SYSTEM'
+        					when 'U' then 'USER'
+    					end as schema_definer_type
+				FROM SYSCAT.SCHEMATA
+				ORDER by schema_name", 
+				function(err, tables, moreResultSets) {		
 				if ( !err ) { 
 					res.render('tablelist', {
 						"tablelist" : tables
-						
-					 });
-
-					
+					 });					
 				} else {
 				   res.send("error occurred " + err.message);
 				}
@@ -188,26 +193,27 @@ exports.listSysTables = function(ibmdb,connString) {
 
 ## Troubleshooting
 
-The primary source of debugging information for your Bluemix app is the logs. To see them, run the following command using the Cloud Foundry CLI:
+The primary source of debugging information for your IBM Cloud app is the logs. To see them, run the following command using the Cloud Foundry CLI:
 
   ```
-  $ cf logs dashdbnodesample --recent
+  $ ibmcloud cf logs dashdbnodesample --recent
   ```
-For more detailed information on troubleshooting your application, see the [Troubleshooting section](https://www.ng.bluemix.net/docs/troubleshoot/tr.html) in the Bluemix documentation.
+For more detailed information on troubleshooting your application, 
+see the [Troubleshooting section](https://cloud.ibm.com/docs/cloud-foundry-public?topic=cloud-foundry-public-runtimes) in the IBM Cloud documentation.
 
 ## Contribute
 We are more than happy to accept external contributions to this project, be it in the form of issues or pull requests. If you find a bug or want an enhancement to be added to the sample application, please report via the [issues section](https://github.com/IBM-Bluemix/dashdb-nodejs-helloworld/issues) or even better, fork the project and submit a pull request with your fix. Pull requests will be evaulated on an individual basis based on value add to the sample application.
 
 
 ## Privacy Notice
-The dashdb-nodejs-helloworld sample web application includes code to track deployments to Bluemix and other Cloud Foundry platforms. The following information is sent to a [Deployment Tracker](https://github.com/cloudant-labs/deployment-tracker) service on each deployment:
+The dashdb-nodejs-helloworld sample web application includes code to track deployments to IBM Cloud and other Cloud Foundry platforms. The following information is sent to a [Deployment Tracker](https://github.com/cloudant-labs/deployment-tracker) service on each deployment:
 
 * Application Name (application_name)
 * Space ID (space_id)
 * Application Version (application_version)
 * Application URIs (application_uris)
 
-This data is collected from the VCAP_APPLICATION environment variable in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
+This data is collected from the VCAP_APPLICATION environment variable in IBM Cloud and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
 
 ### Disabling Deployment Tracking
 
@@ -216,7 +222,7 @@ Deployment tracking can be disabled by removing `require("cf-deployment-tracker-
 ### Related Links
 - [IBM DB2 node.js API](https://www.npmjs.org/package/ibm_db#api)
 
-- [Using IBM Db2 from node.js](https://www.ibm.com/developerworks/community/blogs/pd/entry/using_ibm_db2_from_node_js4?lang=en)
+- [Using IBM Db2 from node.js](https://github.com/ibmdb/node-ibm_db/)
 
-- [IBM Db2 v10.5 Knowledge Center](https://www-01.ibm.com/support/knowledgecenter/SSEPGG_10.5.0/com.ibm.db2.luw.kc.doc/welcome.html)
-- [IBM Db2 developerWorks](http://www.ibm.com/developerworks/data/products/db2/)
+- [IBM Db2 Knowledge Center](https://www-01.ibm.com/support/knowledgecenter/SSEPGG_10.5.0)
+- [IBM Db2 community](https://community.ibm.com/community/user/hybriddatamanagement/communities/db2-home)

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,11 +2,11 @@
 declared-services:
   dashDB-nodesample:
     label: dashDB
-    plan: Entry
+    plan: Lite
 applications:
 # replace the host variable below with your own unique one, as this one can be already taken
 - name: dashdbnodesample
-  memory: 512M
+  memory: 256M
   instances: 1
   path: .
   host: dashdbnodesample

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 declared-services:
   dashDB-nodesample:
-    label: dashDB
+    label: dashDB For Transactions
     plan: Lite
 applications:
 # replace the host variable below with your own unique one, as this one can be already taken

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,13 +7,13 @@ exports.listSysTables = function(ibmdb,connString) {
 			 res.send("error occurred " + err.message);
 			}
 			else {
-				conn.query("SELECT FIRST_NAME, LAST_NAME, EMAIL, WORK_PHONE from GOSALESHR.employee FETCH FIRST 10 ROWS ONLY", function(err, tables, moreResultSets) {
+				conn.query("select tabschema, owner, tabname, type, tableorg from SYSCAT.TABLES fetch first 10 rows", function(err, tables, moreResultSets) {
 							
 							
 				if ( !err ) { 
 					res.render('tablelist', {
 						"tablelist" : tables,
-						"tableName" : "10 rows from the GOSALESHR.EMPLOYEE table",
+						"tableName" : "10 rows from the SYSCAT.TABLES table",
 						"message": "Congratulations. Your connection to dashDB is successful."
 						
 					 });


### PR DESCRIPTION
Db2WH offers no free plan anymore, but Db2 (dashdb for Transactions) does.

updated all Bluemix links for current equivalents